### PR TITLE
Fix Gladiator by replacing GLD with the correct GLA.

### DIFF
--- a/LMeter/Config/BarColorsConfig.cs
+++ b/LMeter/Config/BarColorsConfig.cs
@@ -12,7 +12,7 @@ namespace LMeter.Config
         public ConfigColor DRKColor = new ConfigColor(209f / 255f, 38f / 255f, 204f / 255f, 1f);
         public ConfigColor WARColor = new ConfigColor(207f / 255f, 38f / 255f, 33f / 255f, 1f);
         public ConfigColor GNBColor = new ConfigColor(121f / 255f, 109f / 255f, 48f / 255f, 1f);
-        public ConfigColor GLDColor = new ConfigColor(168f / 255f, 210f / 255f, 230f / 255f, 1f);
+        public ConfigColor GLAColor = new ConfigColor(168f / 255f, 210f / 255f, 230f / 255f, 1f);
         public ConfigColor MRDColor = new ConfigColor(207f / 255f, 38f / 255f, 33f / 255f, 1f);
 
         public ConfigColor SCHColor = new ConfigColor(134f / 255f, 87f / 255f, 255f / 255f, 1f);
@@ -44,7 +44,7 @@ namespace LMeter.Config
 
         public ConfigColor GetColor(Job job) => job switch
         {
-            Job.GLD => this.GLDColor,
+            Job.GLA => this.GLAColor,
             Job.MRD => this.MRDColor,
             Job.PLD => this.PLDColor,
             Job.WAR => this.WARColor,
@@ -163,9 +163,9 @@ namespace LMeter.Config
 
                 ImGui.NewLine();
                 
-                vector = GLDColor.Vector;
-                ImGui.ColorEdit4("GLD", ref vector, ImGuiColorEditFlags.AlphaPreview | ImGuiColorEditFlags.AlphaBar);
-                this.GLDColor.Vector = vector;
+                vector = GLAColor.Vector;
+                ImGui.ColorEdit4("GLA", ref vector, ImGuiColorEditFlags.AlphaPreview | ImGuiColorEditFlags.AlphaBar);
+                this.GLAColor.Vector = vector;
                 
                 vector = MRDColor.Vector;
                 ImGui.ColorEdit4("MRD", ref vector, ImGuiColorEditFlags.AlphaPreview | ImGuiColorEditFlags.AlphaBar);

--- a/LMeter/Helpers/CharacterState.cs
+++ b/LMeter/Helpers/CharacterState.cs
@@ -66,7 +66,7 @@ namespace LMeter.Helpers
 
             if (type == JobType.Tanks)
             {
-                return new List<Job>() { Job.GLD, Job.MRD, Job.PLD, Job.WAR, Job.DRK, Job.GNB };
+                return new List<Job>() { Job.GLA, Job.MRD, Job.PLD, Job.WAR, Job.DRK, Job.GNB };
             }
 
             if (type == JobType.Casters)
@@ -127,7 +127,7 @@ namespace LMeter.Helpers
 
     public enum Job
     {
-        GLD = 1,
+        GLA = 1,
         MRD = 3,
         PLD = 19,
         WAR = 21,


### PR DESCRIPTION
Gladiator's shorthand is `GLA` and not `GLD`. This mistake results in bars, icons, etc not being identified as the job's given string doesn't match the expected string.