### PR TITLE
Add on|off arg to lm toggle command.

### DIFF
--- a/LMeter/Config/MeterListConfig.cs
+++ b/LMeter/Config/MeterListConfig.cs
@@ -33,11 +33,18 @@ namespace LMeter.Config
             this.DrawMeterTable(size.AddY(-padY), padX);
         }
         
-        public void ToggleMeter(int meterIndex)
+        public void ToggleMeter(int meterIndex, bool? toggle = null)
         {
             if (meterIndex >= 0 && meterIndex < this.Meters.Count)
             {
-                this.Meters[meterIndex].VisibilityConfig.AlwaysHide ^= true;
+                if (toggle == null)
+                {
+                    this.Meters[meterIndex].VisibilityConfig.AlwaysHide ^= true;
+                }
+                else
+                {
+                    this.Meters[meterIndex].VisibilityConfig.AlwaysHide = !(bool) toggle;
+                }
             }
         }
         

--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -58,7 +58,7 @@ namespace LMeter
                                 + "/lm end → Ends current ACT Encounter.\n"
                                 + "/lm clear → Clears all ACT encounter log data.\n"
                                 + "/lm ct <number> → Toggles clickthrough status for the given profile.\n"
-                                + "/lm toggle <number> → Toggles visibility for the given profile.",
+                                + "/lm toggle <number> [true|false] → Toggles visibility for the given profile.",
                     ShowInHelp = true
                 }
             );
@@ -142,7 +142,7 @@ namespace LMeter
                     this.Clear();
                     break;
                 case { } argument when argument.StartsWith("toggle"):
-                    _config.MeterList.ToggleMeter(GetIntArg(argument) - 1);
+                    _config.MeterList.ToggleMeter(GetIntArg(argument) - 1, GetBoolArg(argument, 2));
                     break;
                 case { } argument when argument.StartsWith("ct"):
                     _config.MeterList.ToggleClickThrough(GetIntArg(argument) - 1);
@@ -157,6 +157,12 @@ namespace LMeter
         {
             string[] args1 = argument.Split(" ");
             return args1.Length > 1 && int.TryParse(args1[1], out int num) ? num : 0;
+        }
+
+        private static bool? GetBoolArg(string argument, int index = 1)
+        {
+            string[] args1 = argument.Split(" ");
+            return args1.Length > index && bool.TryParse(args1[index], out bool res) ? res : null;
         }
 
         private void ToggleWindow()

--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -58,7 +58,7 @@ namespace LMeter
                                 + "/lm end → Ends current ACT Encounter.\n"
                                 + "/lm clear → Clears all ACT encounter log data.\n"
                                 + "/lm ct <number> → Toggles clickthrough status for the given profile.\n"
-                                + "/lm toggle <number> [true|false] → Toggles visibility for the given profile.",
+                                + "/lm toggle <number> [on|off] → Toggles visibility for the given profile.",
                     ShowInHelp = true
                 }
             );
@@ -162,7 +162,7 @@ namespace LMeter
         private static bool? GetBoolArg(string argument, int index = 1)
         {
             string[] args1 = argument.Split(" ");
-            return args1.Length > index && bool.TryParse(args1[index], out bool res) ? res : null;
+            return args1.Length > index && args1[index].Equals("on") ? true : args1[index].Equals("off") ? false : null;
         }
 
         private void ToggleWindow()


### PR DESCRIPTION
This optional argument allows better usage in macros to prevent accidental toggles in the wrong direction.
`/lm toggle <index> on` -> shows profile (i.e. sets AlwaysHide to false)
`/lm toggle <index> off` -> hides profile (i.e. sets AlwaysHide to true)
Old behavior (`/lm toggle <index>`) remains unchanged.

Works the same as e.g. `/hotbar display`.