### PR TITLE
Allow working on LMeter on Linux

### DIFF
--- a/LMeter/LMeter.csproj
+++ b/LMeter/LMeter.csproj
@@ -39,7 +39,16 @@
     <PropertyGroup>
         <DalamudVersion>dev</DalamudVersion>
         <DalamudLocal>../dalamud/</DalamudLocal>
+    </PropertyGroup>
+    
+    <!-- Dalamud Configuration (Windows-specific) -->
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <DalamudXIVLauncher>$(APPDATA)\XIVLauncher\addon\Hooks\$(DalamudVersion)</DalamudXIVLauncher>
+    </PropertyGroup>
+    
+    <!-- Dalamud Configuration (Linux-specific) -->
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+        <DalamudXIVLauncher>$(HOME)/.xlcore/dalamud/Hooks/$(DalamudVersion)</DalamudXIVLauncher>
     </PropertyGroup>
 
     <!-- Assembly Reference Locations -->


### PR DESCRIPTION
Another adjustment could be made for OSX, but I cannot set my Mac up at the moment so someone else would have to give input on where XLCore stores the hooks there.