### PR TITLE
Fix IINACT compatibility

### DIFF
--- a/LMeter/Plugin.cs
+++ b/LMeter/Plugin.cs
@@ -92,9 +92,8 @@ namespace LMeter
             // Initialize Fonts
             Singletons.Register(new FontsManager(pluginInterface.UiBuilder, config.FontConfig.Fonts.Values));
 
-            // Connect to ACT
+            // Register ACTClient
             ACTClient actClient = new ACTClient(config.ACTConfig);
-            actClient.Start();
             Singletons.Register(actClient);
 
             // Create profile on first load

--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -63,6 +63,7 @@ namespace LMeter
                 }
             );
 
+            _clientState.Login += OnLogin;
             _clientState.Logout += OnLogout;
             _pluginInterface.UiBuilder.OpenConfigUi += OpenConfigUi;
             _pluginInterface.UiBuilder.Draw += Draw;
@@ -123,6 +124,11 @@ namespace LMeter
             {
                 _configRoot.PushConfig(_config);
             }
+        }
+
+        private void OnLogin(object? sender, EventArgs? args)
+        {
+            Singletons.Get<ACTClient>().Start();
         }
 
         private void OnLogout(object? sender, EventArgs? args)


### PR DESCRIPTION
Move ACTClient connection from plugin start to character login in order to ensure connection attempt after IINACT (which is now a Dalamud plugin) has started. 