### PR TITLE
Add support with compiling with Dalamud libs from environment variable

### DIFF
--- a/LMeter/LMeter.csproj
+++ b/LMeter/LMeter.csproj
@@ -38,6 +38,7 @@
     <!-- Dalamud Configuration -->
     <PropertyGroup>
         <DalamudVersion>dev</DalamudVersion>
+        <DalamudHome>$(DALAMUD_HOME)/</DalamudHome>
         <DalamudLocal>../dalamud/</DalamudLocal>
         <DalamudXIVLauncher>$(APPDATA)\XIVLauncher\addon\Hooks\$(DalamudVersion)</DalamudXIVLauncher>
     </PropertyGroup>
@@ -46,6 +47,7 @@
     <PropertyGroup>
         <AssemblySearchPaths>
             $(AssemblySearchPaths);
+            $(DalamudHome);
             $(DalamudLocal);
             $(DalamudXIVLauncher);
         </AssemblySearchPaths>


### PR DESCRIPTION
Uses the semi-standard DALAMUD_HOME environment variable, found now even in the SamplePlugin example.

https://github.com/goatcorp/SamplePlugin/blob/bb392ec32036faebc246680f7fef0a5425376eaa/SamplePlugin/SamplePlugin.csproj#L36