### PR TITLE
Add Support for Connecting to IINACT via Dalamud IPC

### DIFF
--- a/LMeter/ACT/ACTClient.cs
+++ b/LMeter/ACT/ACTClient.cs
@@ -24,6 +24,7 @@ namespace LMeter.ACT
         private Task? _receiveTask;
         private ACTEvent? _lastEvent;
 
+        public const string SubscriptionMessage = """{"call":"subscribe","events":["CombatData"]}""";
         public ConnectionStatus Status { get; private set; }
         public List<ACTEvent> PastEvents { get; private set; }
 
@@ -107,9 +108,8 @@ namespace LMeter.ACT
                 Status = ConnectionStatus.Connecting;
                 await _socket.ConnectAsync(new Uri(host), _cancellationTokenSource.Token);
 
-                string subscribe = "{\"call\":\"subscribe\",\"events\":[\"CombatData\"]}";
                 await _socket.SendAsync(
-                        Encoding.UTF8.GetBytes(subscribe),
+                        Encoding.UTF8.GetBytes(SubscriptionMessage),
                         WebSocketMessageType.Text,
                         endOfMessage: true,
                         _cancellationTokenSource.Token);

--- a/LMeter/ACT/ACTClient.cs
+++ b/LMeter/ACT/ACTClient.cs
@@ -9,55 +9,44 @@ using System.Threading.Tasks;
 using Dalamud.Game.Gui;
 using Dalamud.Game.Text;
 using Dalamud.Logging;
+using Dalamud.Plugin;
 using LMeter.Config;
 using LMeter.Helpers;
 using Newtonsoft.Json;
 
 namespace LMeter.ACT
 {
-    public enum ConnectionStatus
-    {
-        NotConnected,
-        Connected,
-        ShuttingDown,
-        Connecting,
-        ConnectionFailed
-    }
-
-    public class ACTClient : IPluginDisposable
+    public class ACTClient : IACTClient
     {
         private ACTConfig _config;
         private ClientWebSocket _socket;
         private CancellationTokenSource _cancellationTokenSource;
         private Task? _receiveTask;
         private ACTEvent? _lastEvent;
-        private ConnectionStatus _status;
-        private List<ACTEvent> _pastEvents;
 
-        public static ConnectionStatus Status => Singletons.Get<ACTClient>()._status;
-        public static List<ACTEvent> PastEvents => Singletons.Get<ACTClient>()._pastEvents;
+        public ConnectionStatus Status { get; private set; }
+        public List<ACTEvent> PastEvents { get; private set; }
 
-        public ACTClient(ACTConfig config)
+        public ACTClient(ACTConfig config, DalamudPluginInterface dpi)
         {
             _config = config;
             _socket = new ClientWebSocket();
             _cancellationTokenSource = new CancellationTokenSource();
-            _status = ConnectionStatus.NotConnected;
-            _pastEvents = new List<ACTEvent>();
+            Status = ConnectionStatus.NotConnected;
+            PastEvents = new List<ACTEvent>();
         }
 
-        public static ACTEvent? GetEvent(int index = -1)
+        public ACTEvent? GetEvent(int index = -1)
         {
-            ACTClient client = Singletons.Get<ACTClient>();
-            if (index >= 0 && index < client._pastEvents.Count)
+            if (index >= 0 && index < PastEvents.Count)
             {
-                return client._pastEvents[index];
+                return PastEvents[index];
             }
             
-            return client._lastEvent;
+            return _lastEvent;
         }
 
-        public static void EndEncounter()
+        public void EndEncounter()
         {
             ChatGui chat = Singletons.Get<ChatGui>();
             XivChatEntry message = new XivChatEntry()
@@ -72,7 +61,7 @@ namespace LMeter.ACT
         public void Clear()
         {
             _lastEvent = null;
-            _pastEvents = new List<ACTEvent>();
+            PastEvents = new List<ACTEvent>();
             if (_config.ClearACT)
             {
                 ChatGui chat = Singletons.Get<ChatGui>();
@@ -86,16 +75,15 @@ namespace LMeter.ACT
             }
         }
 
-        public static void RetryConnection(string address)
+        public void RetryConnection()
         {
-            ACTClient client = Singletons.Get<ACTClient>();
-            client.Reset();
-            client.Start();
+            Reset();
+            Start();
         }
 
         public void Start()
         {
-            if (_status != ConnectionStatus.NotConnected)
+            if (Status != ConnectionStatus.NotConnected)
             {
                 PluginLog.Error("Cannot start, ACTClient needs to be reset!");
                 return;
@@ -107,7 +95,7 @@ namespace LMeter.ACT
             }
             catch (Exception ex)
             {
-                _status = ConnectionStatus.ConnectionFailed;
+                Status = ConnectionStatus.ConnectionFailed;
                 this.LogConnectionFailure(ex.ToString());
             }
         }
@@ -116,7 +104,7 @@ namespace LMeter.ACT
         {
             try
             {
-                _status = ConnectionStatus.Connecting;
+                Status = ConnectionStatus.Connecting;
                 await _socket.ConnectAsync(new Uri(host), _cancellationTokenSource.Token);
 
                 string subscribe = "{\"call\":\"subscribe\",\"events\":[\"CombatData\"]}";
@@ -128,7 +116,7 @@ namespace LMeter.ACT
             }
             catch (Exception ex)
             {
-                _status = ConnectionStatus.ConnectionFailed;
+                Status = ConnectionStatus.ConnectionFailed;
                 this.LogConnectionFailure(ex.ToString());
                 return;
             }
@@ -136,12 +124,12 @@ namespace LMeter.ACT
             ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[4096]);
             if (buffer.Array is null)
             {
-                _status = ConnectionStatus.ConnectionFailed;
+                Status = ConnectionStatus.ConnectionFailed;
                 this.LogConnectionFailure("Failed to allocate receive buffer!");
                 return;
             }
 
-            _status = ConnectionStatus.Connected;
+            Status = ConnectionStatus.Connected;
             PluginLog.Information("Successfully Established ACT Connection");
             try
             {
@@ -186,11 +174,11 @@ namespace LMeter.ACT
                                         {
                                             if (!newEvent.IsEncounterActive())
                                             {
-                                                _pastEvents.Add(newEvent);
+                                                PastEvents.Add(newEvent);
 
-                                                while (_pastEvents.Count > _config.EncounterHistorySize)
+                                                while (PastEvents.Count > _config.EncounterHistorySize)
                                                 {
-                                                    _pastEvents.RemoveAt(0);
+                                                    PastEvents.RemoveAt(0);
                                                 }
                                             }
 
@@ -207,7 +195,7 @@ namespace LMeter.ACT
                         }
                     }
                 }
-                while (_status == ConnectionStatus.Connected);
+                while (Status == ConnectionStatus.Connected);
             }
             catch
             {
@@ -215,7 +203,7 @@ namespace LMeter.ACT
             }
             finally
             {
-                if (_status != ConnectionStatus.ShuttingDown)
+                if (Status != ConnectionStatus.ShuttingDown)
                 {
                     this.Shutdown();
                 }
@@ -224,7 +212,7 @@ namespace LMeter.ACT
 
         public void Shutdown()
         {
-            _status = ConnectionStatus.ShuttingDown;
+            Status = ConnectionStatus.ShuttingDown;
             _lastEvent = null;
             if (_socket.State == WebSocketState.Open ||
                 _socket.State == WebSocketState.Connecting)
@@ -251,7 +239,7 @@ namespace LMeter.ACT
             }
 
             _socket.Dispose();
-            _status = ConnectionStatus.NotConnected;
+            Status = ConnectionStatus.NotConnected;
         }
 
         public void Reset()
@@ -259,7 +247,7 @@ namespace LMeter.ACT
             this.Shutdown();
             _socket = new ClientWebSocket();
             _cancellationTokenSource = new CancellationTokenSource();
-            _status = ConnectionStatus.NotConnected;
+            Status = ConnectionStatus.NotConnected;
         }
 
         private void LogConnectionFailure(string error)

--- a/LMeter/ACT/IACTClient.cs
+++ b/LMeter/ACT/IACTClient.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Dalamud.Plugin;
+using LMeter.Config;
+using LMeter.Helpers;
+
+
+namespace LMeter.ACT
+{
+    public enum ConnectionStatus
+    {
+        NotConnected,
+        Connected,
+        ShuttingDown,
+        Connecting,
+        ConnectionFailed
+    }
+
+    public interface IACTClient : IPluginDisposable
+    {
+        public static IACTClient Current => 
+            Singletons.Get<LMeterConfig>().ACTConfig.IINACTMode 
+                ? Singletons.Get<IINACTClient>() 
+                : Singletons.Get<ACTClient>();
+
+        public static IACTClient GetNewClient()
+        {
+            Singletons.DeleteActClients();
+
+            ACTConfig config = Singletons.Get<LMeterConfig>().ACTConfig;
+            DalamudPluginInterface dpi = Singletons.Get<DalamudPluginInterface>();
+
+            IACTClient client = config.IINACTMode
+                ? new IINACTClient(config, dpi)
+                : new ACTClient(config, dpi);
+            Singletons.Register(client);
+            return client;
+        }
+
+        public ConnectionStatus Status { get; }
+        public List<ACTEvent> PastEvents { get; }
+
+        public void Clear();
+        public void EndEncounter();
+        public ACTEvent? GetEvent(int index = -1);
+        public void Start();
+        public void RetryConnection();
+    }
+}

--- a/LMeter/ACT/IINACTClient.cs
+++ b/LMeter/ACT/IINACTClient.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Game.Gui;
+using Dalamud.Game.Text;
+using Dalamud.Logging;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using LMeter.Config;
+using LMeter.Helpers;
+using Newtonsoft.Json.Linq;
+
+namespace LMeter.ACT
+{
+    public class IINACTClient : IACTClient
+    {
+        private readonly ACTConfig _config;
+        private readonly DalamudPluginInterface _dpi;
+        private ACTEvent? _lastEvent;
+        private readonly ICallGateProvider<JObject, bool> _combatEventReaderIpc;
+
+        private const string LMeterSubscriptionIpcEndpoint = "LMeter.SubscriptionReceiver";
+        private const string IINACTSubscribeIpcEndpoint = "IINACT.CreateSubscriber";
+        private const string IINACTUnsubscribeIpcEndpoint = "IINACT.Unsubscribe";
+        private const string IINACTProviderEditEndpoint = "IINACT.IpcProvider." + LMeterSubscriptionIpcEndpoint;
+
+        public ConnectionStatus Status { get; private set; }
+        public List<ACTEvent> PastEvents { get; private set; }
+
+        public IINACTClient(ACTConfig config, DalamudPluginInterface dpi)
+        {
+            _config = config;
+            _dpi = dpi;
+            Status = ConnectionStatus.NotConnected;
+            PastEvents = new List<ACTEvent>();
+
+            _combatEventReaderIpc = _dpi.GetIpcProvider<JObject, bool>(LMeterSubscriptionIpcEndpoint);
+            _combatEventReaderIpc.RegisterFunc(ReceiveIpcMessage);
+        }
+
+        public ACTEvent? GetEvent(int index = -1)
+        {
+            if (index >= 0 && index < PastEvents.Count)
+            {
+                return PastEvents[index];
+            }
+            
+            return _lastEvent;
+        }
+
+        public void EndEncounter()
+        {
+            ChatGui chat = Singletons.Get<ChatGui>();
+            XivChatEntry message = new XivChatEntry()
+            {
+                Message = "end",
+                Type = XivChatType.Echo
+            };
+
+            chat.PrintChat(message);
+        }
+
+        public void Clear()
+        {
+            _lastEvent = null;
+            PastEvents = new List<ACTEvent>();
+            if (_config.ClearACT)
+            {
+                ChatGui chat = Singletons.Get<ChatGui>();
+                XivChatEntry message = new XivChatEntry()
+                {
+                    Message = "clear",
+                    Type = XivChatType.Echo
+                };
+
+                chat.PrintChat(message);
+            }
+        }
+
+        public void RetryConnection()
+        {
+            Reset();
+            Start();
+        }
+
+        public void Start()
+        {
+            if (Status != ConnectionStatus.NotConnected)
+            {
+                PluginLog.Error("Cannot start, IINACTClient needs to be reset!");
+                return;
+            }
+
+            if (!Connect()) return;
+
+            Status = ConnectionStatus.Connected;
+            PluginLog.Information("Successfully subscribed to IINACT");
+        }
+
+        private bool Connect()
+        {
+            Status = ConnectionStatus.Connecting;
+
+            try
+            {
+                var connectSuccess = _dpi
+                    .GetIpcSubscriber<string, bool>(IINACTSubscribeIpcEndpoint)
+                    .InvokeFunc(LMeterSubscriptionIpcEndpoint);
+                if (!connectSuccess) return false;
+            }
+            catch (Exception ex)
+            {
+                Status = ConnectionStatus.ConnectionFailed;
+                PluginLog.Debug("Failed to setup IINACT subscription!");
+                PluginLog.Verbose(ex.ToString());
+                return false;
+            }
+            
+            try
+            {
+                _dpi
+                    .GetIpcSubscriber<JObject, bool>(IINACTProviderEditEndpoint)
+                    .InvokeAction(JObject.Parse("""{"call":"subscribe","events":["CombatData"]}"""));
+            }
+            catch (Exception ex)
+            {
+                Status = ConnectionStatus.ConnectionFailed;
+                PluginLog.Debug("Failed to finalize IINACT subscription!");
+                PluginLog.Verbose(ex.ToString());
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool ReceiveIpcMessage(JObject data)
+        {
+            try
+            {
+                ACTEvent? newEvent = data.ToObject<ACTEvent?>();
+
+                if (newEvent?.Encounter is not null &&
+                    newEvent?.Combatants is not null &&
+                    newEvent.Combatants.Any() &&
+                    (CharacterState.IsInCombat() || !newEvent.IsEncounterActive()))
+                {
+                    if (!(_lastEvent is not null &&
+                          _lastEvent.IsEncounterActive() == newEvent.IsEncounterActive() &&
+                          _lastEvent.Encounter is not null &&
+                          _lastEvent.Encounter.Duration.Equals(newEvent.Encounter.Duration)))
+                    {
+                        if (!newEvent.IsEncounterActive())
+                        {
+                            PastEvents.Add(newEvent);
+
+                            while (PastEvents.Count > _config.EncounterHistorySize)
+                            {
+                                PastEvents.RemoveAt(0);
+                            }
+                        }
+
+                        newEvent.Timestamp = DateTime.UtcNow;
+                        _lastEvent = newEvent;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Verbose(ex.ToString());
+                return false;
+            }
+
+            return true;
+        }
+        
+        public void Shutdown()
+        {
+            try
+            {
+                var success = _dpi
+                    .GetIpcSubscriber<string, bool>(IINACTUnsubscribeIpcEndpoint)
+                    .InvokeFunc(LMeterSubscriptionIpcEndpoint);
+
+                PluginLog.Information(
+                    success
+                        ? "Successfully unsubscribed from IINACT"
+                        : "Failed to unsubscribe from IINACT"
+                );
+            }
+            catch (Exception)
+            {
+                // don't throw when closing
+            }
+
+            Status = ConnectionStatus.NotConnected;
+        }
+
+        public void Reset()
+        {
+            this.Shutdown();
+            Status = ConnectionStatus.NotConnected;
+        }
+
+        public void Dispose()
+        {
+            _combatEventReaderIpc.UnregisterFunc();
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Shutdown();
+            }
+        }
+    }
+}

--- a/LMeter/ACT/IINACTClient.cs
+++ b/LMeter/ACT/IINACTClient.cs
@@ -23,6 +23,7 @@ namespace LMeter.ACT
         private const string IINACTSubscribeIpcEndpoint = "IINACT.CreateSubscriber";
         private const string IINACTUnsubscribeIpcEndpoint = "IINACT.Unsubscribe";
         private const string IINACTProviderEditEndpoint = "IINACT.IpcProvider." + LMeterSubscriptionIpcEndpoint;
+        private readonly JObject SubscriptionMessageObject = JObject.Parse(ACTClient.SubscriptionMessage);
 
         public ConnectionStatus Status { get; private set; }
         public List<ACTEvent> PastEvents { get; private set; }
@@ -120,7 +121,7 @@ namespace LMeter.ACT
             {
                 _dpi
                     .GetIpcSubscriber<JObject, bool>(IINACTProviderEditEndpoint)
-                    .InvokeAction(JObject.Parse("""{"call":"subscribe","events":["CombatData"]}"""));
+                    .InvokeAction(SubscriptionMessageObject);
             }
             catch (Exception ex)
             {

--- a/LMeter/Config/ACTConfig.cs
+++ b/LMeter/Config/ACTConfig.cs
@@ -23,7 +23,7 @@ namespace LMeter.Config
         
         public IConfigPage GetDefault() => new ACTConfig();
 
-        public bool IINACTMode = true;
+        public bool IINACTMode = false;
         public string ACTSocketAddress;
 
         public int EncounterHistorySize = 15;

--- a/LMeter/Config/VisibilityConfig.cs
+++ b/LMeter/Config/VisibilityConfig.cs
@@ -64,7 +64,7 @@ namespace LMeter.Config
                 return false;
             }
 
-            if (this.HideIfNotConnected && ACTClient.Status != ConnectionStatus.Connected)
+            if (this.HideIfNotConnected && IACTClient.Current.Status != ConnectionStatus.Connected)
             {
                 return false;
             }

--- a/LMeter/Helpers/Singletons.cs
+++ b/LMeter/Helpers/Singletons.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using LMeter.ACT;
 
 namespace LMeter.Helpers
 {
@@ -45,6 +46,21 @@ namespace LMeter.Helpers
             }
         }
 
+        public static void DeleteActClients()
+        {
+            ActiveInstances.TryRemove(typeof(ACTClient), out var client1);
+            if (client1 != null)
+            {
+                ((IACTClient) client1).Dispose();
+            }
+
+            ActiveInstances.TryRemove(typeof(IINACTClient), out var client2);
+            if (client2 != null)
+            {
+                ((IACTClient) client2).Dispose();
+            }
+        }
+        
         public static void Dispose()
         {
             foreach (object singleton in ActiveInstances.Values)

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -182,7 +182,7 @@ namespace LMeter.Meter
                     _previewEvent = ACTEvent.GetTestData();
                 }
 
-                ACTEvent? actEvent = this.GeneralConfig.Preview ? _previewEvent : ACTClient.GetEvent(_eventIndex);
+                ACTEvent? actEvent = this.GeneralConfig.Preview ? _previewEvent : IACTClient.Current.GetEvent(_eventIndex);
 
                 (localPos, size) = this.HeaderConfig.DrawHeader(localPos, size, actEvent?.Encounter, drawList);
                 drawList.AddRectFilled(localPos, localPos + size, this.GeneralConfig.BackgroundColor.Base);
@@ -253,7 +253,7 @@ namespace LMeter.Meter
                     selected = true;
                 }
 
-                List<ACTEvent> events = ACTClient.PastEvents;
+                List<ACTEvent> events = IACTClient.Current.PastEvents;
                 if (events.Count > 0)
                 {
                     ImGui.Separator();

--- a/LMeter/Plugin.cs
+++ b/LMeter/Plugin.cs
@@ -93,9 +93,8 @@ namespace LMeter
             Singletons.Register(new FontsManager(pluginInterface.UiBuilder, config.FontConfig.Fonts.Values));
 
             // Connect to ACT
-            ACTClient actClient = new ACTClient(config.ACTConfig);
+            IACTClient actClient = IACTClient.GetNewClient(); // Singleton Registry is done internally here
             actClient.Start();
-            Singletons.Register(actClient);
 
             // Create profile on first load
             if (config.FirstLoad && config.MeterList.Meters.Count == 0)

--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using Dalamud.Game.ClientState;
 using Dalamud.Game.Command;
@@ -96,7 +96,7 @@ namespace LMeter
 
         public void Clear()
         {
-            Singletons.Get<ACTClient>().Clear();
+            IACTClient.Current.Clear();
             foreach (var meter in _config.MeterList.Meters)
             {
                 meter.Clear();
@@ -135,7 +135,7 @@ namespace LMeter
             switch (arguments)
             {
                 case "end":
-                    ACTClient.EndEncounter();
+                    IACTClient.Current.EndEncounter();
                     break;
                 case "clear":
                     this.Clear();


### PR DESCRIPTION
Uses Dalamud's Inter Plugin Communication feature to connect to the Dalamud plugin version of IINACT. This bypasses using the WebSocket, and allows sharing memory from within the same process, instead of needing a background thread and a de/serialization process.

More importantly, it bypasses the need to connect using a WebSocket. This is useful as some builds of wine/proton on linux do not allow a process to connect to a WebSocket being hosted by the same pid.

This does not replace the standard WebSocket connection mode, and simply adds the option to use IPC instead. Reverting back to WebSocket mode is available in the plugin config options.