### PR TITLE
rank is not the bar index

### DIFF
--- a/LMeter/ACT/DataStructures/Combatant.cs
+++ b/LMeter/ACT/DataStructures/Combatant.cs
@@ -35,7 +35,7 @@ public class Combatant : IActData<Combatant>
 
     [TextTag]
     [JsonIgnore]
-    public string Rank = string.Empty;
+    public int Rank = 1;
 
     [TextTag]
     [JsonProperty("Job")]

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -380,6 +380,13 @@ namespace LMeter.Meter
                 // This has the issue that some settings can't behave properly and or don't update till the following combat update/fight
                 List<Combatant> sortedCombatants = [.. this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType)];
 
+                // add rank to the sorted combatants, with this we have the real rank of the player even if he is not in lenght of the bars
+                int rank = 1;
+                foreach (var combatant in sortedCombatants)
+                {
+                    combatant.Rank = rank++;
+                }
+
                 float top = this.GeneralConfig.DataType switch
                 {
                     MeterDataType.Damage => sortedCombatants[0].DamageTotal?.Value ?? 0,
@@ -432,7 +439,6 @@ namespace LMeter.Meter
                 for (; currentIndex < maxIndex; currentIndex++)
                 {
                     Combatant combatant = sortedCombatants[currentIndex];
-                    combatant.Rank = (currentIndex + 1).ToString();
                     UpdatePlayerName(combatant, playerName);
 
                     float current = this.GeneralConfig.DataType switch
@@ -574,7 +580,7 @@ namespace LMeter.Meter
 
         private void MovePlayerIntoViewableRange(List<Combatant> sortedCombatants, int scrollPosition, string playerName)
         {
-            int oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name.Contains("YOU") || combatant.Name.Contains(playerName));
+            int oldPlayerIndex = sortedCombatants.FindIndex(combatant => combatant.Name == "YOU" || combatant.Name == playerName);
             if (oldPlayerIndex == -1)
             {
                 return;
@@ -594,7 +600,7 @@ namespace LMeter.Meter
         {
             combatant.NameOverwrite = this.BarConfig.UseCharacterName switch
             {
-                true when combatant.Name.Contains("YOU") => localPlayerName,
+                true when combatant.Name.Contains("YOU") => combatant.Name.Replace("YOU", localPlayerName),
                 false when combatant.NameOverwrite is not null => null,
                 _ => combatant.NameOverwrite
             };


### PR DESCRIPTION
Currently, rank is the bar index when it should be the position in the sorted combatants.

For example, if you're set to show 8 bars but as DPS in an alliance raid / hunt you are the 12th top DPS and you have set to always displayer the player your rank will be display as 8th, not as 12th.

First I've changed Rank to be an int, there is no reason to be a string and this will help to not convert to string the combatants not show on the window.

Then I've added the rank after getting the sorted combatants.

However, they were some code not working properly if you also choose to replace YOU with the player name if you have summoned your companion/chocobo.

Currently, in the ACT struct your companion is named as: "Name (YOU)", and the original code was trying to find a string that contains YOU but replace the whole string with the player name. So for example, "Chocobo (YOU)" if the player was named "FFXIV Player" was replaced to "FFXIV Player" instead of "Chocobo (FFXIV Player)" this is now fixed and consistent to how other players companions show.

Now when we were trying to Move the Player Into viewable range they were as well a check to the Name string containing "YOU" or PlayerName, that was as well wrong since the chocobo will match those cases too, so I fixed using an exact match, we do not need to do partial match for it.

I've tested all of this and works correctly now

**Before the change**

*12 DPS in a party*
![image](https://github.com/user-attachments/assets/252aa3d4-6832-4136-ab2b-089e94768871)

*Chocobo a Player end with the sane name*
![image](https://github.com/user-attachments/assets/061e61b4-c312-44c4-a8b8-40816d50ae83)


After the change

*12 DPS in a party*
![image](https://github.com/user-attachments/assets/5b339f76-7dba-4d95-ae60-be9c5aa08d82)

*Chocobo a Player have now different name*
![image](https://github.com/user-attachments/assets/ddf8cdb2-6316-4990-a5f6-78b450b1dc15)

