### PR TITLE
Make sure the meter doesn't steal focus

### DIFF
--- a/LMeter/PluginManager.cs
+++ b/LMeter/PluginManager.cs
@@ -34,7 +34,8 @@ namespace LMeter
             ImGuiWindowFlags.NoBackground |
             ImGuiWindowFlags.NoInputs |
             ImGuiWindowFlags.NoBringToFrontOnFocus |
-            ImGuiWindowFlags.NoSavedSettings;
+            ImGuiWindowFlags.NoSavedSettings | 
+            ImGuiWindowFlags.NoFocusOnAppearing;
 
         public PluginManager(
             IClientState clientState,


### PR DESCRIPTION
Simple flag so that wiping (and thus redrawing LMeter) doesn't steal focus away from other plugins for no reason.

My specific use case was trying to type in Chat2 in between pulls and LMeter defocuses the window making my typing hit all my spells instead :)