### PR TITLE
Support grid layouts for bars

### DIFF
--- a/LMeter/Helpers/Enums.cs
+++ b/LMeter/Helpers/Enums.cs
@@ -135,4 +135,10 @@ namespace LMeter.Helpers
         BottomLeft = 7,
         BottomRight = 8,
     }
+
+    public enum BarSizeType
+    {
+        ConstantCount = 0,
+        ConstantSize = 1,
+    }
 }

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -335,23 +335,30 @@ namespace LMeter.Meter
                         layout = CalculateBarLayout(size, this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType).Count);
                     }
 
-                    if (this.BarConfig.ShowColumnHeader && actEvent is not null)
+                    if (this.BarConfig.ShowColumnHeader && actEvent is not null && layout is not null)
                     {
-                        List<Text> columnHeaderTexts = GetColumnHeaderTexts(this.BarTextConfig.Texts, this.BarConfig);
-                        Vector2 columnHeaderSize = new(size.X, this.BarConfig.ColumnHeaderHeight);
-                        drawList.AddRectFilled(
-                            localPos,
-                            localPos + columnHeaderSize,
-                            this.BarConfig.ColumnHeaderColor.Base
-                        );
-                        DrawBarTexts(
-                            drawList,
-                            columnHeaderTexts,
-                            localPos + this.BarConfig.ColumnHeaderOffset,
-                            columnHeaderSize,
-                            jobColor,
-                            actEvent
-                        );
+                        Vector2 columnHeaderSize = new(layout.BarSize.X, this.BarConfig.ColumnHeaderHeight);
+
+                        for (int i = 0; i < layout.Columns; i++)
+                        {
+                            List<Text> columnHeaderTexts = GetColumnHeaderTexts(this.BarTextConfig.Texts, this.BarConfig);
+
+                            var headerPos = localPos.AddX(i * (layout.BarSize.X + this.BarConfig.BarHorizontalGaps));
+
+                            drawList.AddRectFilled(
+                                headerPos,
+                                headerPos + columnHeaderSize,
+                                this.BarConfig.ColumnHeaderColor.Base
+                            );
+                            DrawBarTexts(
+                                drawList,
+                                columnHeaderTexts,
+                                headerPos + this.BarConfig.ColumnHeaderOffset,
+                                columnHeaderSize,
+                                jobColor,
+                                actEvent
+                            );
+                        }
 
                         localPos = localPos.AddY(columnHeaderSize.Y);
                     }

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -625,10 +625,10 @@ namespace LMeter.Meter
             }
         }
 
-        private Vector2 DrawBar(
+        private void DrawBar(
             ImDrawListPtr drawList,
             Vector2 localPos,
-            Vector2 size,
+            Vector2 barSize,
             Combatant combatant,
             ConfigColor jobColor,
             ConfigColor barColor,
@@ -638,19 +638,14 @@ namespace LMeter.Meter
         )
         {
             BarConfig barConfig = this.BarConfig;
-            float barHeight =
-                barConfig.BarHeightType == 0
-                    ? (size.Y - (barConfig.BarCount - 1) * barConfig.BarGaps) / barConfig.BarCount
-                    : barConfig.BarHeight;
 
             Vector2 barPos = localPos;
-            Vector2 barSize = new(size.X, barHeight);
-            Vector2 barFillSize = new(size.X * (current / top), barHeight * barConfig.BarFillHeight);
+            Vector2 barFillSize = new(barSize.X * (current / top), barSize.Y * barConfig.BarFillHeight);
 
             if (barConfig.BarFillHeight != 1f)
             {
-                barPos = barConfig.BarFillDirection == 0 ? barPos.AddY(barHeight - barFillSize.Y) : barPos;
-                Vector2 barBackgroundSize = new(size.X * (current / top), barHeight);
+                barPos = barConfig.BarFillDirection == 0 ? barPos.AddY(barSize.Y - barFillSize.Y) : barPos;
+                Vector2 barBackgroundSize = new(barSize.X * (current / top), barSize.Y);
                 drawList.AddRectFilled(localPos, localPos + barBackgroundSize, barConfig.BarBackgroundColor.Base);
             }
 
@@ -666,7 +661,7 @@ namespace LMeter.Meter
             {
                 uint jobIconId = 62000u + (uint)combatant.Job + 100u * (uint)barConfig.JobIconStyle;
                 Vector2 jobIconPos = localPos + barConfig.JobIconOffset;
-                Vector2 jobIconSize = barConfig.JobIconSizeType == 0 ? Vector2.One * barHeight : barConfig.JobIconSize;
+                Vector2 jobIconSize = barConfig.JobIconSizeType == 0 ? Vector2.One * barSize.Y : barConfig.JobIconSize;
                 if (barConfig.JobIconBackgroundColor.Vector.W > 0f)
                 {
                     Vector2 jobIconBackgroundPos = new(jobIconPos.X, localPos.Y);
@@ -682,7 +677,6 @@ namespace LMeter.Meter
             }
 
             DrawBarTexts(drawList, this.BarTextConfig.Texts, localPos, barSize, jobColor, combatant);
-            return localPos.AddY(barHeight + barConfig.BarGaps);
         }
 
         private static void DrawBarTexts<T>(

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -318,6 +318,23 @@ namespace LMeter.Meter
                         this.GeneralConfig.Rounding
                     );
 
+                    BarLayout? layout = null;
+
+                    if (this.HeaderConfig.ShowFooter)
+                    {
+                        size = size.AddY(-this.HeaderConfig.FooterHeight);
+                    }
+
+                    if (actEvent is not null)
+                    {
+                        if (this.BarConfig.ShowColumnHeader)
+                        {
+                            size = size.AddY(-this.BarConfig.ColumnHeaderHeight);
+                        }
+
+                        layout = CalculateBarLayout(size, this.GetSortedCombatants(actEvent, this.GeneralConfig.DataType).Count);
+                    }
+
                     if (this.BarConfig.ShowColumnHeader && actEvent is not null)
                     {
                         List<Text> columnHeaderTexts = GetColumnHeaderTexts(this.BarTextConfig.Texts, this.BarConfig);
@@ -336,16 +353,11 @@ namespace LMeter.Meter
                             actEvent
                         );
 
-                        (localPos, size) = (localPos.AddY(columnHeaderSize.Y), size.AddY(-columnHeaderSize.Y));
-                    }
-
-                    if (this.HeaderConfig.ShowFooter)
-                    {
-                        size = size.AddY(-this.HeaderConfig.FooterHeight);
+                        localPos = localPos.AddY(columnHeaderSize.Y);
                     }
 
                     ImGui.PushClipRect(localPos, localPos + size, false);
-                    this.DrawBars(drawList, localPos, size, actEvent);
+                    this.DrawBars(drawList, localPos, layout, actEvent);
                     ImGui.PopClipRect();
 
                     if (this.HeaderConfig.ShowFooter)

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -543,15 +543,19 @@ namespace LMeter.Meter
 
             int currentIndex = 0;
             string playerName = Singletons.Get<IPlayerState>().CharacterName ?? "YOU";
-            if (sortedCombatants.Count > barCount)
+            if (sortedCombatants.Count > layout.Bars)
             {
                 int unclampedScroll = _scrollPosition;
-                currentIndex = Math.Clamp(_scrollPosition, 0, sortedCombatants.Count - barCount);
-                _scrollPosition = currentIndex;
 
-                if (margin > 0 && _scrollPosition < unclampedScroll)
+                var hiddenRowCount = (int)Math.Ceiling((float)(sortedCombatants.Count - layout.Bars) / layout.Columns);
+
+                _scrollPosition = Math.Clamp(_scrollPosition, 0, hiddenRowCount);
+
+                currentIndex = _scrollPosition * layout.Columns;
+
+                if (layout.Margin > 0 && _scrollPosition < unclampedScroll)
                 {
-                    _scrollShift = margin;
+                    _scrollShift = layout.Margin;
                 }
 
                 if (unclampedScroll < 0)
@@ -559,7 +563,7 @@ namespace LMeter.Meter
                     _scrollShift = 0;
                 }
 
-                if (this.BarConfig.AlwaysShowSelf && this.BarConfig.BarHeightType == 0)
+                if (this.BarConfig.AlwaysShowSelf && this.BarConfig.BarSizeType == BarSizeType.ConstantCount)
                 {
                     MovePlayerIntoViewableRange(sortedCombatants, _scrollPosition, playerName);
                 }

--- a/LMeter/Meter/MeterWindow.cs
+++ b/LMeter/Meter/MeterWindow.cs
@@ -590,15 +590,7 @@ namespace LMeter.Meter
                         _ => combatant.NameOverwrite,
                     };
 
-                    RoundingOptions rounding = this.BarConfig.MiddleBarRounding;
-                    if (currentIndex == startIndex)
-                    {
-                        rounding = this.BarConfig.TopBarRounding;
-                    }
-                    else if (currentIndex == maxIndex - 1)
-                    {
-                        rounding = this.BarConfig.BottomBarRounding;
-                    }
+                    var rounding = GetRounding(layout, currentRow, currentColumn);
 
                     var barPos = new Vector2(
                         localPos.X + currentColumn * (layout.BarSize.X + this.BarConfig.BarHorizontalGaps),
@@ -618,6 +610,36 @@ namespace LMeter.Meter
                     );
                 }
             }
+        }
+
+        private RoundingOptions GetRounding(BarLayout layout, int row, int column)
+        {
+            var top = row == 0;
+            var bottom = row == layout.Rows - 1;
+            var left = column == 0;
+            var right = column == layout.Columns - 1;
+
+            if (layout.Columns == 1)
+            {
+                return top ? this.BarConfig.TopBarRounding : bottom ? this.BarConfig.BottomBarRounding : this.BarConfig.MiddleBarRounding;
+            }
+
+            if (layout.Rows == 1)
+            {
+                return left ? this.BarConfig.LeftBarRounding : right ? this.BarConfig.RightBarRounding : this.BarConfig.MiddleBarRounding;
+            }
+
+            if (top)
+            {
+                return left ? this.BarConfig.TopLeftBarRounding : right ? this.BarConfig.TopRightBarRounding : this.BarConfig.TopBarRounding;
+            }
+
+            if (bottom)
+            {
+                return left ? this.BarConfig.BottomLeftBarRounding : right ? this.BarConfig.BottomRightBarRounding : this.BarConfig.BottomBarRounding;
+            }
+
+            return left ? this.BarConfig.LeftBarRounding : right ? this.BarConfig.RightBarRounding : this.BarConfig.MiddleBarRounding;
         }
 
         private void DrawBar(


### PR DESCRIPTION
For a while, there's been an ask for horizontal bar layouts (#82). This implements a more generalized version of that which should be able to handle any grid layout like 1x10, 10x1, 5x5, 3x8, and so on.

Summary of changes:
- Add configuration settings needed for grid layouts, keeping default settings as the current 1-column layout
    - Add settings related to columns (e.g. bar width)
    - Rounding options for all cardinal, inter-cardinal, and middle bars
        - Since some settings don't apply to 1xN or Nx1 layouts, only relevant settings are shown for those configurations
    - Update naming of some settings that were named based on the single-column layout
- Calculate bar layout up-front (`CalculateLayout`) and use the calculated layout to place the bars
    - Instead of the iterative approach `DrawBars` used to take, this does some math up front to determine the column and row counts based on the user's configuration and the number of combatants
    - Hopefully this reasonably easy to follow, if it needs clarification, let me know
- Update other elements of the drawing code to work well with grid layouts
    - Split rounding determination out of `DrawBars`, since grid layouts make it more complicated to decide what rounding to use
    - Scrolling scrolls one row at a time instead of one combatant
    - Column headers are drawn at the top of every column

The diff of all of this taken together is confusing, so I've tried to make the commit history clear.